### PR TITLE
fix: clean up all staging buffers when texture readback budget exceeded

### DIFF
--- a/src/core/spectorGpu.ts
+++ b/src/core/spectorGpu.ts
@@ -1248,8 +1248,10 @@ export class SpectorGPU {
         let totalPreviewBytes = 0;
         const MAX_PREVIEW_BYTES = 4 * 1024 * 1024;
 
+        let budgetExceeded = false;
         for (const task of tasks) {
             try {
+                if (budgetExceeded) continue; // Skip preview work; finally block still cleans up
                 if (task.layers === 1) {
                     // Single layer — standard readback
                     const data = new Uint8Array(task.buffers[0].getMappedRange());
@@ -1262,8 +1264,7 @@ export class SpectorGPU {
                         totalPreviewBytes += dataUrl.length;
                         if (totalPreviewBytes > MAX_PREVIEW_BYTES) {
                             Logger.warn('Preview size budget exceeded, skipping remaining textures');
-                            for (const b of task.buffers) { try { b.unmap(); } catch {} b.destroy(); }
-                            break;
+                            budgetExceeded = true; continue;
                         }
                         this._recorderManager.setTexturePreview(task.id, dataUrl);
                     }
@@ -1282,8 +1283,7 @@ export class SpectorGPU {
                     }
                     if (totalPreviewBytes > MAX_PREVIEW_BYTES) {
                         Logger.warn('Preview size budget exceeded, skipping remaining textures');
-                        for (const b of task.buffers) { try { b.unmap(); } catch {} b.destroy(); }
-                        break;
+                        budgetExceeded = true; continue;
                     }
                     // Also set the first face as the main preview
                     if (faceUrls[0]) {


### PR DESCRIPTION
When the 4MB preview budget was exceeded, the loop used `break` which skipped the finally-block cleanup for remaining tasks, leaking their GPU staging buffers. Now sets a `budgetExceeded` flag and `continue`s, so every task's `finally` block runs.

Fixes #1