### PR TITLE
fix: use texture view dimension to detect cubemaps during readback

### DIFF
--- a/src/core/recorders/recorderManager.ts
+++ b/src/core/recorders/recorderManager.ts
@@ -232,6 +232,17 @@ export class RecorderManager {
         return this._destroyedTextures.has(textureId);
     }
 
+    /** Check if any texture view of this texture uses a cube dimension. */
+    public hasTextureCubeView(textureId: string): boolean {
+        for (const view of this._textureViews.values()) {
+            if (view.textureId === textureId &&
+                (view.dimension === 'cube' || view.dimension === 'cube-array')) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     // ─── Texture View ────────────────────────────────────────────────
 
     public recordTextureViewCreation(view: object, texture: object, descriptor: any): string {

--- a/src/core/spectorGpu.ts
+++ b/src/core/spectorGpu.ts
@@ -1185,8 +1185,9 @@ export class SpectorGPU {
                 const width = info.size.width;
                 const height = info.size.height;
                 const layers = info.size.depthOrArrayLayers;
-                // Read all faces for cubes (6 layers), otherwise just layer 0
-                const layerCount = layers === 6 ? 6 : 1;
+                // Read all faces for cubes (6 layers + confirmed cube view), otherwise just layer 0
+                const isCube = layers === 6 && this._recorderManager.hasTextureCubeView(id);
+                const layerCount = isCube ? 6 : 1;
                 const bytesPerRow = Math.ceil((width * bpp) / 256) * 256;
                 const perLayerSize = bytesPerRow * height;
 


### PR DESCRIPTION
Previously, any texture with `depthOrArrayLayers === 6` was assumed to be a cubemap. This misidentified 6-layer 2D array textures (e.g., cascaded shadow maps) as cubemaps, generating incorrect face preview grids.

Now cross-references with texture views: a texture is only treated as a cubemap if it has 6 layers AND at least one view with dimension `cube` or `cube-array`. Added `hasTextureCubeView()` helper to `RecorderManager`.

Fixes #3