### PR TITLE
Change Node.js version matrix to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: 22
+        node-version: [22]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Updated the Node.js version matrix in CI workflow to only use version 22.